### PR TITLE
Added method to delete single key-value-pair

### DIFF
--- a/storage-helper.js
+++ b/storage-helper.js
@@ -14,14 +14,7 @@ class storageHelper {
     static async init() {
         let dataFolder = await fs.getDataFolder();
         try {
-            const file = await dataFolder.getEntry('storage.json');
-            if (file) {
-                return file;
-            }
-            else {
-                throw new Error('Storage file storage.json was not a file.');
-            }
-
+            return await dataFolder.getEntry('storage.json');
         } catch (e) {
             const file = await dataFolder.createEntry('data.json', {type: storage.types.file, overwrite: true});
             if (file.isFile) {
@@ -61,6 +54,15 @@ class storageHelper {
         let object = JSON.parse((await dataFile.read({format: storage.formats.utf8})).toString());
         object[key] = value;
         return await dataFile.write(JSON.stringify(object), {append: false, format: storage.formats.utf8})
+    }
+
+    /**
+     * Deletes a certain key-value-pair from the storage
+     * @param {string} key The key of the deleted pair
+     * @return {Promise<void>}
+     */
+    static async delete(key) {
+        return await this.set(key, undefined);
     }
 
     /**

--- a/test/storageHelper.test.js
+++ b/test/storageHelper.test.js
@@ -101,6 +101,23 @@ describe('storage helper', () => {
         });
     });
 
+    describe('storageHelper.delete()', () => {
+        it('should delete a previously stored value', async done => {
+            expect(Object.keys(JSON.parse(mockFileContents)).length).toBe(1);
+            const storageHelper = require('../storage-helper');
+            await storageHelper.delete('a');
+            expect(Object.keys(JSON.parse(mockFileContents)).length).toBe(0);
+            done();
+        });
+
+        it('should ignore a key that wasn\'t previously stored', async done => {
+            expect(Object.keys(JSON.parse(mockFileContents)).length).toBe(1);
+            const storageHelper = require('../storage-helper');
+            await storageHelper.delete('d');
+            expect(Object.keys(JSON.parse(mockFileContents)).length).toBe(1);
+            done();
+        });
+    });
 
     describe('storageHelper in special situations', () => {
         it('should correctly handle calling reset()', async (done) => {


### PR DESCRIPTION
## What it adds (or fixes):
- Simplified code of the `init()` function
- Added `storageHelper.delete(key)` to delete a singel key-value-pair